### PR TITLE
Modal component close via cross sign

### DIFF
--- a/lib/components/ModalAlert/index.js
+++ b/lib/components/ModalAlert/index.js
@@ -46,6 +46,7 @@ var AlertComponent = function (_Component) {
           inputPlaceholder = _props.inputPlaceholder,
           inputValue = _props.inputValue,
           onConfirm = _props.onConfirm,
+          onClose = _props.onClose,
           confirmDisabled = _props.confirmDisabled,
           confirmLoading = _props.confirmLoading;
 
@@ -53,6 +54,7 @@ var AlertComponent = function (_Component) {
       return _react2.default.createElement(
         'div',
         { className: 'popup__box' },
+        _react2.default.createElement('i', { className: 'ion-close', onClick: onClose }),
         _react2.default.createElement(
           'header',
           { className: 'popup__box__header' },
@@ -118,6 +120,7 @@ AlertComponent.propTypes = {
   inputPlaceholder: _propTypes2.default.string,
 
   onConfirm: _propTypes2.default.func.isRequired,
+  onClose: _propTypes2.default.func.isRequired,
 
   confirmDisabled: _propTypes2.default.bool.isRequired,
 

--- a/lib/components/ModalConfirm/index.js
+++ b/lib/components/ModalConfirm/index.js
@@ -49,6 +49,7 @@ var ConfirmModalComponent = function (_Component) {
           inputType = _props.inputType,
           onConfirm = _props.onConfirm,
           onCancel = _props.onCancel,
+          onClose = _props.onClose,
           confirmDisabled = _props.confirmDisabled,
           cancelDisabled = _props.cancelDisabled,
           confirmLoading = _props.confirmLoading,
@@ -58,6 +59,7 @@ var ConfirmModalComponent = function (_Component) {
       return _react2.default.createElement(
         'div',
         { className: 'popup__box' },
+        _react2.default.createElement('i', { className: 'ion-close', onClick: onClose }),
         _react2.default.createElement(
           'header',
           { className: 'popup__box__header' },
@@ -144,6 +146,7 @@ ConfirmModalComponent.propTypes = {
 
   onConfirm: _propTypes2.default.func.isRequired,
   onCancel: _propTypes2.default.func.isRequired,
+  onClose: _propTypes2.default.func.isRequired,
 
   confirmDisabled: _propTypes2.default.bool.isRequired,
   cancelDisabled: _propTypes2.default.bool.isRequired,

--- a/src/components/ModalAlert/index.js
+++ b/src/components/ModalAlert/index.js
@@ -14,6 +14,7 @@ class AlertComponent extends Component {
     inputPlaceholder: PropTypes.string,
 
     onConfirm: PropTypes.func.isRequired,
+    onClose: PropTypes.func.isRequired,
 
     confirmDisabled: PropTypes.bool.isRequired,
 
@@ -40,12 +41,14 @@ class AlertComponent extends Component {
       inputPlaceholder,
       inputValue,
       onConfirm,
+      onClose,
       confirmDisabled,
       confirmLoading
     } = this.props
 
     return (
       <div className='popup__box'>
+        <i className='ion-close' onClick={onClose} />
         <header className='popup__box__header'>
           <h1 className='popup__box__header__title'>
             <span>{title}</span>

--- a/src/components/ModalConfirm/index.js
+++ b/src/components/ModalConfirm/index.js
@@ -17,6 +17,7 @@ class ConfirmModalComponent extends Component {
 
     onConfirm: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
+    onClose: PropTypes.func.isRequired,
 
     confirmDisabled: PropTypes.bool.isRequired,
     cancelDisabled: PropTypes.bool.isRequired,
@@ -52,6 +53,7 @@ class ConfirmModalComponent extends Component {
       inputType,
       onConfirm,
       onCancel,
+      onClose,
       confirmDisabled,
       cancelDisabled,
       confirmLoading,
@@ -60,6 +62,7 @@ class ConfirmModalComponent extends Component {
 
     return (
       <div className='popup__box'>
+        <i className='ion-close' onClick={onClose} />
         <header className='popup__box__header'>
           <h1 className='popup__box__header__title'>
             <span>{title}</span>

--- a/src/styles/components/_popup.scss
+++ b/src/styles/components/_popup.scss
@@ -77,6 +77,12 @@
     border-radius: $base-border-radius;
     overflow: hidden;
     z-index: 100;
+
+    .ion-close {
+        float: right;
+        margin-right: 0.5em;
+        cursor: pointer;
+    }
 }
 
 .popup__box__header, .popup__box__body, .popup__box__footer{


### PR DESCRIPTION
It should be possible to close the modal component by clicking on on the cross sign in the right top corner. It is standard behaviour expected by the user. (see bootstrap etc)